### PR TITLE
Fix GlobalExceptionHandler warning

### DIFF
--- a/src/main/java/com/runlala/scaffold/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/runlala/scaffold/handler/GlobalExceptionHandler.java
@@ -2,18 +2,20 @@ package com.runlala.scaffold.handler;
 
 import com.runlala.scaffold.dto.R;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @ControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseBody
     public R<String> handleIllegalArgumentException(IllegalArgumentException e, HttpServletRequest request) {
         String requestUrl = request.getRequestURL().toString();
         if (requestUrl.contains("/api")) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
             return R.error(e.getMessage());
         }
 


### PR DESCRIPTION
Fix "Call to 'printStackTrace()' should probably be replaced with more robust logging" warning